### PR TITLE
Corrigido funcionamento do onLoading no ScopedBuilder

### DIFF
--- a/stores/flutter_triple/example/lib/main.dart
+++ b/stores/flutter_triple/example/lib/main.dart
@@ -52,56 +52,52 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   final counter = Counter();
 
-  Widget _floatingButton(bool active) {
-    return FloatingActionButton(
-      onPressed: active ? counter.increment : null,
-      tooltip: active ? 'Increment' : 'no-active',
-      backgroundColor: active ? Theme.of(context).primaryColor : Colors.grey,
-      child: Icon(Icons.add),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
         actions: [
-          IconButton(onPressed: counter.undo, icon: Icon(Icons.arrow_back_ios)),
           IconButton(
-              onPressed: counter.redo, icon: Icon(Icons.arrow_forward_ios)),
+            onPressed: counter.undo,
+            icon: Icon(Icons.arrow_back_ios),
+          ),
+          IconButton(
+            onPressed: counter.redo,
+            icon: Icon(Icons.arrow_forward_ios),
+          ),
         ],
       ),
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            ScopedBuilder<Counter, Exception, int>(
-                store: counter,
-                onLoading: (_, loading) {
-                  return Text(
-                    !loading
-                        ? 'You have pushed the button this many times:'
-                        : 'Carregando...',
-                  );
-                }),
-            ScopedBuilder<Counter, Exception, int>(
-              store: counter,
-              onState: (_, state) {
-                return Text(
+        child: ScopedBuilder<Counter, Exception, int>(
+          store: counter,
+          onLoading: (_) => Text('Carregando...'),
+          onState: (_, state) {
+            return Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text('You have pushed the button this many times:'),
+                Text(
                   '$state',
                   style: Theme.of(context).textTheme.headline4,
-                );
-              },
-            ),
-          ],
+                ),
+              ],
+            );
+          },
         ),
       ),
       floatingActionButton: TripleBuilder<Counter, Exception, int>(
-          store: counter,
-          builder: (_, triple) => _floatingButton(
-                !triple.isLoading || triple.event == TripleEvent.state,
-              )),
+        store: counter,
+        builder: (_, triple) {
+          return FloatingActionButton(
+            onPressed: triple.isLoading ? null : counter.increment,
+            tooltip: triple.isLoading ? 'no-active' : 'Increment',
+            backgroundColor:
+                triple.isLoading ? Colors.grey : Theme.of(context).primaryColor,
+            child: Icon(Icons.add),
+          );
+        },
+      ),
     );
   }
 }

--- a/stores/flutter_triple/lib/src/scoped_builder.dart
+++ b/stores/flutter_triple/lib/src/scoped_builder.dart
@@ -40,14 +40,14 @@ class _ScopedBuilderState<TStore extends Store<TError, TState>,
       onState: (state) {
         if (widget.onState != null) {
           setState(() {
-            child = widget.onState!(context, state);
+            child = widget.onState?.call(context, state);
           });
         }
       },
       onError: (error) {
         if (widget.onError != null) {
           setState(() {
-            child = widget.onError!(context, error);
+            child = widget.onError?.call(context, error);
           });
         }
       },
@@ -55,8 +55,8 @@ class _ScopedBuilderState<TStore extends Store<TError, TState>,
         if (widget.onLoading != null) {
           setState(() {
             child = isLoading
-                ? widget.onLoading!(context)
-                : widget.onState!(context, widget.store.state);
+                ? widget.onLoading?.call(context)
+                : widget.onState?.call(context, widget.store.state);
           });
         }
       },
@@ -74,7 +74,9 @@ class _ScopedBuilderState<TStore extends Store<TError, TState>,
     if (child == null) {
       switch (widget.store.triple.event) {
         case (TripleEvent.loading):
-          child = widget.onLoading?.call(context);
+          child = widget.store.triple.isLoading
+              ? widget.onLoading?.call(context)
+              : widget.onState?.call(context, widget.store.state);
           break;
         case (TripleEvent.error):
           child = widget.onError?.call(context, widget.store.error);
@@ -83,9 +85,15 @@ class _ScopedBuilderState<TStore extends Store<TError, TState>,
           child = widget.onState?.call(context, widget.store.state);
           break;
       }
-      if (child == null) child = widget.onLoading?.call(context);
-      if (child == null) child = widget.onError?.call(context, widget.store.error);
-      if (child == null) child = widget.onState?.call(context, widget.store.state);
+      if (child == null) {
+        child = widget.onLoading?.call(context);
+      }
+      if (child == null) {
+        child = widget.onError?.call(context, widget.store.error);
+      }
+      if (child == null) {
+        child = widget.onState?.call(context, widget.store.state);
+      }
     }
     return child!;
   }

--- a/stores/flutter_triple/lib/src/scoped_builder.dart
+++ b/stores/flutter_triple/lib/src/scoped_builder.dart
@@ -5,7 +5,7 @@ class ScopedBuilder<TStore extends Store<TError, TState>, TError extends Object,
     TState extends Object> extends StatefulWidget {
   final Widget Function(BuildContext context, TState state)? onState;
   final Widget Function(BuildContext context, TError? error)? onError;
-  final Widget Function(BuildContext context, bool isLoading)? onLoading;
+  final Widget Function(BuildContext context)? onLoading;
   final TStore store;
 
   const ScopedBuilder(
@@ -40,22 +40,23 @@ class _ScopedBuilderState<TStore extends Store<TError, TState>,
       onState: (state) {
         if (widget.onState != null) {
           setState(() {
-            child = widget.onState!(context, widget.store.state);
+            child = widget.onState!(context, state);
           });
         }
       },
       onError: (error) {
         if (widget.onError != null) {
           setState(() {
-            child = widget.onError!(context, widget.store.error);
+            child = widget.onError!(context, error);
           });
         }
       },
-      onLoading: (loading) {
-        if (widget.onLoading != null &&
-            (widget.onState == null ? true : widget.store.isLoading)) {
+      onLoading: (isLoading) {
+        if (widget.onLoading != null) {
           setState(() {
-            child = widget.onLoading!(context, widget.store.isLoading);
+            child = isLoading
+                ? widget.onLoading!(context)
+                : widget.onState!(context, widget.store.state);
           });
         }
       },
@@ -71,12 +72,16 @@ class _ScopedBuilderState<TStore extends Store<TError, TState>,
   @override
   Widget build(BuildContext context) {
     if (child == null) {
-      if (widget.onState != null) {
-        child = widget.onState!(context, widget.store.state);
-      } else if (widget.onError != null) {
-        child = widget.onError!(context, widget.store.error);
-      } else if (widget.onLoading != null) {
-        child = widget.onLoading!(context, widget.store.isLoading);
+      switch (widget.store.triple.event) {
+        case (TripleEvent.loading):
+          child = widget.onLoading!(context);
+          break;
+        case (TripleEvent.error):
+          child = widget.onError!(context, widget.store.error);
+          break;
+        case (TripleEvent.state):
+          child = widget.onState!(context, widget.store.state);
+          break;
       }
     }
     return child!;

--- a/stores/flutter_triple/lib/src/scoped_builder.dart
+++ b/stores/flutter_triple/lib/src/scoped_builder.dart
@@ -74,15 +74,18 @@ class _ScopedBuilderState<TStore extends Store<TError, TState>,
     if (child == null) {
       switch (widget.store.triple.event) {
         case (TripleEvent.loading):
-          child = widget.onLoading!(context);
+          child = widget.onLoading?.call(context);
           break;
         case (TripleEvent.error):
-          child = widget.onError!(context, widget.store.error);
+          child = widget.onError?.call(context, widget.store.error);
           break;
         case (TripleEvent.state):
-          child = widget.onState!(context, widget.store.state);
+          child = widget.onState?.call(context, widget.store.state);
           break;
       }
+      if (child == null) child = widget.onLoading?.call(context);
+      if (child == null) child = widget.onError?.call(context, widget.store.error);
+      if (child == null) child = widget.onState?.call(context, widget.store.state);
     }
     return child!;
   }

--- a/triple/lib/src/memento_mixin.dart
+++ b/triple/lib/src/memento_mixin.dart
@@ -35,9 +35,9 @@ mixin MementoMixin<State extends Object, Error extends Object>
 
   @override
   void update(newState) {
-    _addHistory(lastTripleState);
+    _addHistory(lastTripleState.copyWith(isLoading: false));
     super.update(newState);
-    lastTripleState = triple;
+    lastTripleState = triple.copyWith(isLoading: false);
   }
 
   ///Undo the last state value.


### PR DESCRIPTION
Corrigido funcionamento do onLoading no ScopedBuilder.

O mixin do memento também estava se perdendo com o estado do loading ao recuperar algo no histórico. Para resolver o problema, foi definido o estado no histórico sempre com `loading: false`