### PR TITLE
Atualizada versão máxima do import do rx_notifier

### DIFF
--- a/stores/flutter_triple/pubspec.yaml
+++ b/stores/flutter_triple/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   triple: ">=0.0.19 <1.0.0"
-  rx_notifier: ">=0.0.5 <1.0.0"
+  rx_notifier: ">=0.0.5 <2.0.0"
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
No **flutter_triple**,  foi alterada a versão máxima do import **rx_notifier** de `">=0.0.5 <1.0.0"` para `">=0.0.5 <2.0.0"`.