### PR TITLE
Fixed: RangeError in Triple Test (Store)

### DIFF
--- a/triple_test/lib/src/store_test.dart
+++ b/triple_test/lib/src/store_test.dart
@@ -63,6 +63,10 @@ FutureOr<void> storeTest<T extends Store>(
     final expectList = _list is List ? _list : List.from([_list]);
     await runZonedGuarded(() async {
       testTriple(Triple triple, dynamic value) {
+        if (completer.isCompleted) {
+          return;
+        }
+
         final matcher = expectList[i];
         actualList.add('${triple.event.toString().replaceFirst('TripleEvent.', '')}($value)');
         test.expect(matcher is TripleMatcher ? triple : value, matcher);


### PR DESCRIPTION
When store emites tripleState, tripleLoading, tripleState, tripleLoading and my expect have [tripleState, tripleLoading, tripleState] cause one exception:

`RangeError (index): Invalid value: Not in inclusive range 0..2: 3`

