### PR TITLE
Triple test throws a compilation error - Flutter 2.2.2

### DIFF
--- a/triple_test/lib/src/store_test.dart
+++ b/triple_test/lib/src/store_test.dart
@@ -67,7 +67,8 @@ FutureOr<void> storeTest<T extends Store>(
           return;
         }
         final matcher = expectList[i];
-        actualList.add('${triple.event.toString().replaceFirst('TripleEvent.', '')}($value)');
+        actualList.add(
+            '${triple.event.toString().replaceFirst('TripleEvent.', '')}($value)');
         test.expect(matcher is TripleMatcher ? triple : value, matcher);
         i++;
         if (i >= expectList.length) {
@@ -115,7 +116,8 @@ class TripleMatcher extends test.Matcher {
   const TripleMatcher(this.event);
 
   @override
-  test.Description describe(test.Description description) => description.add('Triple State');
+  test.Description describe(test.Description description) =>
+      description.add('Triple State');
 
   @override
   bool matches(covariant Triple triple, Map matchState) {
@@ -129,9 +131,9 @@ class TripleMatcher extends test.Matcher {
 }
 
 class VerifyError {
-  final String message;
+  final String? message;
   VerifyError(this.message);
 
   @override
-  String toString() => message;
+  String toString() => message.toString();
 }


### PR DESCRIPTION
Change `VerifyError` message attribute to accept a nullable String. Changes based on `flutter_test -> test_api-0.3.0` for **Flutter 2.2.2.**

close #44 