### PR TITLE
docs(using-flutter-triple): remove `$` from variables

### DIFF
--- a/doc/docs/getting-started/2.using-flutter-triple.md
+++ b/doc/docs/getting-started/2.using-flutter-triple.md
@@ -172,14 +172,14 @@ The type of selectors changes depending on the reactive tool you are using in th
 
 ```dart
 //StreamStore
-Stream<int> myState$ = counter.selectState;
-Stream<Exception> myError$ = counter.selectError;
-Stream<bool> myLoading$ = counter.selectLoading;
+Stream<int> myState = counter.selectState;
+Stream<Exception> myError = counter.selectError;
+Stream<bool> myLoading = counter.selectLoading;
 
 //NotifierStore
-ValueListenable<int> myState$ = counter.selectState;
-ValueListenable<Exception?> myError$ = counter.selectError;
-ValueListenable<bool> myLoading$ = counter.selectLoading;
+ValueListenable<int> myState = counter.selectState;
+ValueListenable<Exception?> myError = counter.selectError;
+ValueListenable<bool> myLoading = counter.selectLoading;
 
 ```
 


### PR DESCRIPTION
Because there is no other place in the documentation using the same notation, and there's _apparently_ no need for it, we should remove it.