### PR TITLE
docs(testing): add references to functions

### DIFF
--- a/doc/docs/getting-started/7.testing.mdx
+++ b/doc/docs/getting-started/7.testing.mdx
@@ -47,7 +47,7 @@ whenObserve<MyException, int>(
 
 ## Testing Stores
 
-The `flutter_test` gives us the [test()](https://api.flutter.dev/flutter/flutter_test/test.html) function to describe what will be tested in a prepared scope. `triple_test` makes it easier to test Triple Stores using the [storeTest()](https://pub.dev/documentation/triple_test/latest/triple_test/storeTest.html).
+The `flutter_test` gives us the [test()](https://api.flutter.dev/flutter/flutter_test/test.html) function to describe what will be tested in a prepared scope. `triple_test` makes it easier to test Triple Stores using [storeTest()](https://pub.dev/documentation/triple_test/latest/triple_test/storeTest.html).
 
 ```dart
   storeTest<TestImplementsMock>(

--- a/doc/docs/getting-started/7.testing.mdx
+++ b/doc/docs/getting-started/7.testing.mdx
@@ -47,7 +47,7 @@ whenObserve<MyException, int>(
 
 ## Testing Stores
 
-The flutter_test gives us the test() function to describe what will be tested in a prepared scope. triple_test makes it easier to test Triple Stores using the storeTest() function instead of test();
+The `flutter_test` gives us the [test()](https://api.flutter.dev/flutter/flutter_test/test.html) function to describe what will be tested in a prepared scope. `triple_test` makes it easier to test Triple Stores using the [storeTest()](https://pub.dev/documentation/triple_test/latest/triple_test/storeTest.html).
 
 ```dart
   storeTest<TestImplementsMock>(


### PR DESCRIPTION
To make easier for the reader to lookup them up and simplify comparison.